### PR TITLE
Improve handling of spreads on jsx element

### DIFF
--- a/__tests__/__fixtures__/with-babel-plugin/01-jsx/code.js
+++ b/__tests__/__fixtures__/with-babel-plugin/01-jsx/code.js
@@ -8,3 +8,6 @@ const GDot5 = props => <g.Img width={100}/>;
 const GDot6 = props => <g.Span width={100}/>;
 const GDot7 = props => <g.Span css={redStyles} marginLeft={5}/>;
 const GDot8 = props => <g.Span css={redStyles} className="my-class"/>;
+const GDot9 = props => <g.Span css={styles} {...props}/>;
+const GDot10 = props => <g.Span {...props} css={styles}/>;
+const GDot11 = props => <g.Span marginTop={5} {...props}/>;

--- a/__tests__/__fixtures__/with-babel-plugin/01-jsx/output.js
+++ b/__tests__/__fixtures__/with-babel-plugin/01-jsx/output.js
@@ -8,11 +8,11 @@ const GDot3 = props => <div css={{
   marginTop: 5
 }} />;
 
-const GDot4 = props => <div onClick={handler} css={{
+const GDot4 = props => <div css={{
   marginTop: 10,
   marginTop: 5,
   marginBottom: "5"
-}} />;
+}} onClick={handler} />;
 
 const GDot5 = props => <img width={100} />;
 
@@ -24,4 +24,12 @@ const GDot7 = props => <span css={{ ...redStyles,
   marginLeft: 5
 }} />;
 
-const GDot8 = props => <span className="my-class" css={redStyles} />;
+const GDot8 = props => <span css={redStyles} className="my-class" />;
+
+const GDot9 = props => <span css={styles} {...props} />;
+
+const GDot10 = props => <span {...props} css={styles} />;
+
+const GDot11 = props => <span {...props} css={{ ...props.css,
+  marginTop: 5
+}} />;

--- a/__tests__/__fixtures__/without-babel-plugin/02-jsx/code.js
+++ b/__tests__/__fixtures__/without-babel-plugin/02-jsx/code.js
@@ -8,3 +8,6 @@ const GDot5 = props => <g.Img width={100}/>;
 const GDot6 = props => <g.Span width={100}/>;
 const GDot7 = props => <g.Span css={redStyles} marginLeft={5}/>;
 const GDot8 = props => <g.Span css={redStyles} className="my-class"/>;
+const GDot9 = props => <g.Span css={styles} {...props}/>;
+const GDot10 = props => <g.Span {...props} css={styles}/>;
+const GDot11 = props => <g.Span marginTop={5} {...props}/>;

--- a/__tests__/__fixtures__/without-babel-plugin/02-jsx/output.js
+++ b/__tests__/__fixtures__/without-babel-plugin/02-jsx/output.js
@@ -27,3 +27,11 @@ const GDot7 = props => <span className={css({ ...redStyles,
 })} />;
 
 const GDot8 = props => <span className={cx("my-class", redStyles)} />;
+
+const GDot9 = props => <span {...props} className={cx(props.className, styles)} />;
+
+const GDot10 = props => <span {...props} className={cx(props.className, styles)} />;
+
+const GDot11 = props => <span {...props} className={cx(props.className, {
+  marginTop: 5
+})} />;


### PR DESCRIPTION
Turns 

```jsx
<g.Span marginTop={5} {...props}/>
```

into

```jsx
<span {...props} css={{ ...props.css, marginTop: 5}} /> // with babelPlugin
<span {...props} className={cx(props.className, {marginTop: 5})} /> // without babelPlugin
```

Closes #5 