### PR TITLE
Update readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You'll need to use [`babel-codemod`](https://github.com/square/babel-codemod) to
 
 - First, install this plugin: `yarn add babel-plugin-glamorous-to-emotion -D`
 
-- Then run it: `npx babel-codemod --plugin glamorous-to-emotion "src/**/*.js"` or a similar variation depending on your directory structure.
+- Then run it: `npx babel-codemod --plugin babel-plugin-glamorous-to-emotion "src/**/*.js"` or a similar variation depending on your directory structure.
 
 This will put you fully in emotion-land.
 


### PR DESCRIPTION
need to fix instructions, otherwise it throws (on node version 9.7.1)
```
Error: unable to resolve a plugin from source: glamorous-to-emotion
    at PluginLoader.<anonymous> (/Users/danielberndt/.npm/_npx/24575/lib/node_modules/babel-codemod/src/PluginLoader.ts:14:11)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/danielberndt/.npm/_npx/24575/lib/node_modules/babel-codemod/src/PluginLoader.js:4:58)
    at <anonymous>
```