### PR TITLE
Don't treat `innerRef` as css property

### DIFF
--- a/__tests__/__fixtures__/with-babel-plugin/01-jsx/code.js
+++ b/__tests__/__fixtures__/with-babel-plugin/01-jsx/code.js
@@ -11,3 +11,4 @@ const GDot8 = props => <g.Span css={redStyles} className="my-class"/>;
 const GDot9 = props => <g.Span css={styles} {...props}/>;
 const GDot10 = props => <g.Span {...props} css={styles}/>;
 const GDot11 = props => <g.Span marginTop={5} {...props}/>;
+const GDot12 = props => <g.Div marginTop={5} innerRef={handler}/>;

--- a/__tests__/__fixtures__/with-babel-plugin/01-jsx/output.js
+++ b/__tests__/__fixtures__/with-babel-plugin/01-jsx/output.js
@@ -33,3 +33,7 @@ const GDot10 = props => <span {...props} css={styles} />;
 const GDot11 = props => <span {...props} css={{ ...props.css,
   marginTop: 5
 }} />;
+
+const GDot12 = props => <div ref={handler} css={{
+  marginTop: 5
+}} />;

--- a/__tests__/__fixtures__/without-babel-plugin/02-jsx/code.js
+++ b/__tests__/__fixtures__/without-babel-plugin/02-jsx/code.js
@@ -11,3 +11,4 @@ const GDot8 = props => <g.Span css={redStyles} className="my-class"/>;
 const GDot9 = props => <g.Span css={styles} {...props}/>;
 const GDot10 = props => <g.Span {...props} css={styles}/>;
 const GDot11 = props => <g.Span marginTop={5} {...props}/>;
+const GDot12 = props => <g.Div marginTop={5} innerRef={handler}/>;

--- a/__tests__/__fixtures__/without-babel-plugin/02-jsx/output.js
+++ b/__tests__/__fixtures__/without-babel-plugin/02-jsx/output.js
@@ -35,3 +35,7 @@ const GDot10 = props => <span {...props} className={cx(props.className, styles)}
 const GDot11 = props => <span {...props} className={cx(props.className, {
   marginTop: 5
 })} />;
+
+const GDot12 = props => <div ref={handler} className={css({
+  marginTop: 5
+})} />;

--- a/index.js
+++ b/index.js
@@ -157,6 +157,9 @@ module.exports = function(babel) {
         return withBabelPlugin;
       } else if (jsxKey.name === "className") {
         classNameAttr = attr;
+      } else if (jsxKey.name === "innerRef") {
+        // turn `innerRef` into `ref`
+        jsxKey.name = "ref";
       } else {
         // ignore event handlers
         if (jsxKey.name.match(/on[A-Z]/)) return true;


### PR DESCRIPTION
This PR will treat `innerRef` correctly.

It turns

```jsx
<g.Div marginTop={5} innerRef={handler}/>;
```

into

```jsx
<div ref={handler} css={{marginTop: 5}} />;
```

Closes #13