### PR TITLE
Don't use "key" prop as a style attribute

### DIFF
--- a/__tests__/__fixtures__/mode-className/01-jsx-className/code.js
+++ b/__tests__/__fixtures__/mode-className/01-jsx-className/code.js
@@ -15,3 +15,4 @@ const GDot12 = props => <g.Div marginTop={5} innerRef={handler}/>;
 const GDot13 = props => <Div marginTop={5}/>;
 const GDot14 = props => <StyledSpan marginTop={5}>content</StyledSpan>;
 const GDot15 = props => <other.StyledSpan marginTop={5}/>;
+const GDot16 = props => <g.Div key="key" css={{marginTop: 5}}/>;

--- a/__tests__/__fixtures__/mode-className/01-jsx-className/output.js
+++ b/__tests__/__fixtures__/mode-className/01-jsx-className/output.js
@@ -50,3 +50,7 @@ const GDot14 = props => <span className={css({
 })}>content</span>;
 
 const GDot15 = props => <other.StyledSpan marginTop={5} />;
+
+const GDot16 = props => <div key="key" className={css({
+  marginTop: 5
+})} />;

--- a/__tests__/__fixtures__/mode-withBabelPlugin/01-jsx-withBabelPlugin/code.js
+++ b/__tests__/__fixtures__/mode-withBabelPlugin/01-jsx-withBabelPlugin/code.js
@@ -15,3 +15,4 @@ const GDot12 = props => <g.Div marginTop={5} innerRef={handler}/>;
 const GDot13 = props => <Div marginTop={5}/>;
 const GDot14 = props => <StyledSpan marginTop={5}>content</StyledSpan>;
 const GDot15 = props => <other.StyledSpan marginTop={5}/>;
+const GDot16 = props => <g.Div key="key" css={{marginTop: 5}}/>;

--- a/__tests__/__fixtures__/mode-withBabelPlugin/01-jsx-withBabelPlugin/output.js
+++ b/__tests__/__fixtures__/mode-withBabelPlugin/01-jsx-withBabelPlugin/output.js
@@ -47,3 +47,7 @@ const GDot14 = props => <span css={{
 }}>content</span>;
 
 const GDot15 = props => <other.StyledSpan marginTop={5} />;
+
+const GDot16 = props => <div key="key" css={{
+  marginTop: 5
+}} />;

--- a/__tests__/__fixtures__/mode-withJsxPragma/01-jsx-withJsxPragma/code.js
+++ b/__tests__/__fixtures__/mode-withJsxPragma/01-jsx-withJsxPragma/code.js
@@ -15,3 +15,4 @@ const GDot12 = props => <g.Div marginTop={5} innerRef={handler}/>;
 const GDot13 = props => <Div marginTop={5}/>;
 const GDot14 = props => <StyledSpan marginTop={5}>content</StyledSpan>;
 const GDot15 = props => <other.StyledSpan marginTop={5}/>;
+const GDot16 = props => <g.Div key="key" css={{marginTop: 5}}/>;

--- a/__tests__/__fixtures__/mode-withJsxPragma/01-jsx-withJsxPragma/output.js
+++ b/__tests__/__fixtures__/mode-withJsxPragma/01-jsx-withJsxPragma/output.js
@@ -50,3 +50,7 @@ const GDot14 = props => <span css={{
 }}>content</span>;
 
 const GDot15 = props => <other.StyledSpan marginTop={5} />;
+
+const GDot16 = props => <div key="key" css={{
+  marginTop: 5
+}} />;

--- a/index.js
+++ b/index.js
@@ -167,6 +167,7 @@ module.exports = function(babel) {
       } else {
         // ignore event handlers
         if (jsxKey.name.match(/on[A-Z]/)) return true;
+        if (jsxKey.name === "key") return true;
 
         // ignore generic attributes like 'id'
         if (htmlElementAttributes["*"].includes(jsxKey.name)) return true;


### PR DESCRIPTION
I just realised that `<glamorous.div key={key} css={{}}/>` gets turned into `<div css={{key: key}}/>`