### PR TITLE
Don't spread css prop

### DIFF
--- a/__tests__/__fixtures__/mode-withBabelPlugin/01-jsx-withBabelPlugin/output.js
+++ b/__tests__/__fixtures__/mode-withBabelPlugin/01-jsx-withBabelPlugin/output.js
@@ -30,7 +30,7 @@ const GDot9 = props => <span css={styles} {...props} />;
 
 const GDot10 = props => <span {...props} css={styles} />;
 
-const GDot11 = props => <span {...props} css={{ ...props.css,
+const GDot11 = props => <span {...props} css={{
   marginTop: 5
 }} />;
 

--- a/__tests__/__fixtures__/mode-withJsxPragma/01-jsx-withJsxPragma/output.js
+++ b/__tests__/__fixtures__/mode-withJsxPragma/01-jsx-withJsxPragma/output.js
@@ -33,7 +33,7 @@ const GDot9 = props => <span css={styles} {...props} />;
 
 const GDot10 = props => <span {...props} css={styles} />;
 
-const GDot11 = props => <span {...props} css={{ ...props.css,
+const GDot11 = props => <span {...props} css={{
   marginTop: 5
 }} />;
 

--- a/index.js
+++ b/index.js
@@ -187,18 +187,6 @@ module.exports = function(babel) {
     });
 
     if (stylesArguments.length > 0) {
-      // if something is spread onto the element, this spread may contain a css prop
-      if (mode !== MODES.className && spreadsAttrs.length) {
-        // we only need to deal with spreads, if `css` is not explicitely set
-        if (!originalCssValue) {
-          spreadsAttrs.forEach(attr =>
-            stylesArguments.unshift(
-              t.spreadElement(t.memberExpression(attr.argument, t.identifier("css")))
-            )
-          );
-        }
-      }
-
       // if the css property was the only object, we don't need to use it's spreaded version
       const stylesObject =
         originalCssValue && stylesArguments.length === 1


### PR DESCRIPTION
When initially writing the code, I didn't fully understand how the `css` prop works. I somehow assumed that the css prop would be passed to the underlying component. But what happens instead is that the `css` gets transformed into a `className`.

So it's not necessary to spread a parent's `css` prop onto the child. As the parent's css prop has been converted into a `className`